### PR TITLE
add encryption/decryption service

### DIFF
--- a/src/EPR.Common/EPR.Common.Authorization.Test/Services/CryptoServicesTests.cs
+++ b/src/EPR.Common/EPR.Common.Authorization.Test/Services/CryptoServicesTests.cs
@@ -1,0 +1,103 @@
+﻿namespace EPR.Common.Authorization.Test.Services;
+
+using EPR.Common.Authorization.Services;
+
+[TestClass]
+public class CryptoServicesTests
+{
+    private string _encryptionKey;
+
+    [TestInitialize]
+    public void Setup()
+    {
+        var encryptionKeyGenerator = new EncryptionKeyGenerator();
+        _encryptionKey = encryptionKeyGenerator.GenerateBase64EncodedKey();
+         
+    }
+
+    [TestMethod]
+    public void EncryptText_ValidInput_ReturnsEncryptedText()
+    {
+        // Arrange
+        var cryptoService = new CryptoServices();
+        var textToEncrypt = "Hello, world!";
+
+        // Act
+        var encryptedText = cryptoService.EncryptText(textToEncrypt, _encryptionKey);
+
+        // Assert
+        Assert.IsFalse(string.IsNullOrEmpty(encryptedText));
+        Assert.AreNotEqual(textToEncrypt, encryptedText);
+    }
+
+    [TestMethod]
+    public void EncryptText_ComprehensiveTests()
+    {
+        // Arrange
+        var cryptoService = new CryptoServices();
+        var textToEncrypt = "Hello, world!";
+
+        // Act
+        var encryptedText = cryptoService.EncryptText(textToEncrypt, _encryptionKey);
+
+        // Assert
+        Assert.IsFalse(string.IsNullOrEmpty(encryptedText), "Encrypted text should not be null or empty.");
+        Assert.AreNotEqual(textToEncrypt, encryptedText, "Encrypted text should not be the same as the original text.");
+
+        // Try decrypting the encrypted text to ensure it's reversible
+        var decryptedText = cryptoService.DecryptText(encryptedText, _encryptionKey);
+        Assert.AreEqual(textToEncrypt, decryptedText, "Decrypted text should match the original text.");
+
+        // Test with empty string as input
+        var encryptedEmpty = cryptoService.EncryptText("", _encryptionKey);
+        Assert.IsNotNull(encryptedEmpty, "Encrypted text for empty input should not be null.");
+        Assert.AreNotEqual("", encryptedEmpty, "Encrypted text for empty input should not be empty.");
+
+        // Test with long text
+        var longText = new string('A', 1000); // Creating a long string
+        var encryptedLongText = cryptoService.EncryptText(longText, _encryptionKey);
+        Assert.IsNotNull(encryptedLongText, "Encrypted text for long input should not be null.");
+        Assert.AreNotEqual(longText, encryptedLongText, "Encrypted text for long input should not be the same as the original text.");
+
+        // Test with null input
+        Assert.ThrowsException<ArgumentNullException>(() => cryptoService.EncryptText(null, _encryptionKey), "Encrypting null input should throw ArgumentNullException.");
+
+        // Test with null encryption key
+        Assert.ThrowsException<ArgumentNullException>(() => cryptoService.EncryptText("SomeText", null), "Encrypting with null encryption key should throw ArgumentNullException.");
+
+        // Test with invalid encryption key format
+        var invalidKey = "InvalidKey";
+        Assert.ThrowsException<FormatException>(() => cryptoService.EncryptText("SomeText", invalidKey), "Encrypting with invalid encryption key format should throw FormatException.");
+    }
+
+
+    [TestMethod]
+    public void DecryptText_ValidEncryptedText_ReturnsOriginalText()
+    {
+        // Arrange
+        var cryptoService = new CryptoServices();
+        var originalText = "Hello, world!";
+        var encryptedText = cryptoService.EncryptText(originalText, _encryptionKey);
+
+        // Act
+        var decryptedText = cryptoService.DecryptText(encryptedText, _encryptionKey);
+
+        // Assert
+        Assert.AreEqual(originalText, decryptedText);
+    }
+
+    [TestMethod]
+    [ExpectedException(typeof(FormatException))]
+    public void DecryptText_InvalidKey_ThrowsArgumentException()
+    {
+        // Arrange
+        var cryptoService = new CryptoServices();
+        var encryptedText = "EncryptedText";
+        var invalidKey = "InvalidKey";
+
+        // Act
+       cryptoService.DecryptText(encryptedText, invalidKey);
+
+       //Expected exception is formatException
+    }
+}

--- a/src/EPR.Common/EPR.Common.Authorization.Test/Services/EncryptionKeyGenerator.cs
+++ b/src/EPR.Common/EPR.Common.Authorization.Test/Services/EncryptionKeyGenerator.cs
@@ -1,0 +1,38 @@
+﻿namespace EPR.Common.Authorization.Test.Services;
+
+using AutoFixture;
+using AutoFixture.AutoMoq;
+using System.Security.Cryptography;
+
+public class EncryptionKeyGenerator
+{
+    private readonly IFixture _fixture;
+
+    public EncryptionKeyGenerator()
+    {
+        _fixture = new Fixture().Customize(new AutoMoqCustomization());
+        CustomizeStringGeneration();
+    }
+
+    private void CustomizeStringGeneration()
+    {
+        _fixture.Customizations.Add(new StringGenerator(() =>
+        {
+            var randomBytes = GenerateRandomBytes(32);
+            return Convert.ToBase64String(randomBytes);
+        }));
+    }
+
+    public string GenerateBase64EncodedKey()
+    {
+        return _fixture.Create<string>();
+    }
+
+    private byte[] GenerateRandomBytes(int length)
+    {
+        var randomBytes = new byte[length];
+        using var rng = new RNGCryptoServiceProvider();
+        rng.GetBytes(randomBytes);
+        return randomBytes;
+    }
+}

--- a/src/EPR.Common/EPR.Common.Authorization/Extensions/ServiceCollectionExtensions.cs
+++ b/src/EPR.Common/EPR.Common.Authorization/Extensions/ServiceCollectionExtensions.cs
@@ -1,9 +1,8 @@
 ﻿namespace EPR.Common.Authorization.Extensions;
 
-using System.Diagnostics.CodeAnalysis;
-using System.Net.Http.Headers;
 using Config;
 using Constants;
+using Services;
 using Handlers;
 using Interfaces;
 using Microsoft.AspNetCore.Authorization;
@@ -11,6 +10,8 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Requirements;
 using Sessions;
+using System.Diagnostics.CodeAnalysis;
+using System.Net.Http.Headers;
 
 [ExcludeFromCodeCoverage]
 public static class ServiceCollectionExtensions
@@ -77,6 +78,7 @@ public static class ServiceCollectionExtensions
             .AddScoped<IAuthorizationHandler, AccountManagementPolicyHandler<T>>()
             .AddScoped<IAuthorizationHandler, RegulatorBasicPolicyHandler<T>>()
             .AddScoped<IAuthorizationHandler, RegulatorAdminPolicyHandler<T>>()
+            .AddScoped<ICryptoServices, CryptoServices>()
             .AddHttpClient(FacadeConstants.FacadeAPIClient, client =>
             {
                 client.BaseAddress =

--- a/src/EPR.Common/EPR.Common.Authorization/Interfaces/ICryptoServices.cs
+++ b/src/EPR.Common/EPR.Common.Authorization/Interfaces/ICryptoServices.cs
@@ -1,0 +1,7 @@
+﻿namespace EPR.Common.Authorization.Interfaces;
+
+public interface ICryptoServices
+{
+    string EncryptText(string textToEncrypt, string encryptionKey);
+    string DecryptText(string encryptedText, string encryptionKey);
+}

--- a/src/EPR.Common/EPR.Common.Authorization/Services/CryptoServices.cs
+++ b/src/EPR.Common/EPR.Common.Authorization/Services/CryptoServices.cs
@@ -1,0 +1,51 @@
+﻿namespace EPR.Common.Authorization.Services;
+
+using Interfaces;
+using System.Security.Cryptography;
+using System.Text;
+
+public class CryptoServices : ICryptoServices
+{
+    private const int NonceSize = 12;
+    private const int TagSize = 16;
+
+    public string EncryptText(string textToEncrypt, string encryptionKey)
+    {
+        var plainTextBytes = Encoding.UTF8.GetBytes(textToEncrypt);
+
+        using var aesGcm = new AesGcm(Convert.FromBase64String(encryptionKey));
+        var nonce = new byte[NonceSize];
+        RandomNumberGenerator.Fill(nonce);
+
+        var encryptedData = new byte[plainTextBytes.Length];
+        var tag = new byte[TagSize];
+
+        aesGcm.Encrypt(nonce, plainTextBytes, encryptedData, tag);
+
+        var encryptedResult = new byte[nonce.Length + encryptedData.Length + tag.Length];
+        Buffer.BlockCopy(nonce, 0, encryptedResult, 0, nonce.Length);
+        Buffer.BlockCopy(encryptedData, 0, encryptedResult, nonce.Length, encryptedData.Length);
+        Buffer.BlockCopy(tag, 0, encryptedResult, nonce.Length + encryptedData.Length, tag.Length);
+
+        return Convert.ToBase64String(encryptedResult);
+    }
+
+    public string DecryptText(string encryptedText, string encryptionKey)
+    {
+        var encryptedData = Convert.FromBase64String(encryptedText);
+        using var aesGcm = new AesGcm(Convert.FromBase64String(encryptionKey));
+
+        var nonce = new byte[NonceSize];
+        var cipherText = new byte[encryptedData.Length - nonce.Length - TagSize];
+        var tag = new byte[TagSize];
+
+        Buffer.BlockCopy(encryptedData, 0, nonce, 0, nonce.Length);
+        Buffer.BlockCopy(encryptedData, nonce.Length, cipherText, 0, cipherText.Length);
+        Buffer.BlockCopy(encryptedData, nonce.Length + cipherText.Length, tag, 0, tag.Length);
+
+        var decryptedData = new byte[cipherText.Length];
+        aesGcm.Decrypt(nonce, cipherText, tag, decryptedData);
+
+        return Encoding.UTF8.GetString(decryptedData);
+    }
+}


### PR DESCRIPTION
A new crypto service to be used to encrypt values and decrypt values. AesGcm algorithm is used to drive the logic. (https://learn.microsoft.com/en-us/dotnet/api/system.security.cryptography.aesgcm?view=net-8.0) the methods would need to get the encryption key as a parameter, hence it will be the responsibility of the consumers to get to keyVault and grab the encryption key.

Also the logic involved tagging and hence the encryption value will contain the tag and decryption method will use the attached tag to the value to decrypt.