### PR TITLE
Changed the way in which claims are retrieved. 

### DIFF
--- a/src/EPR.Common/EPR.Common.Authorization/Extensions/ClaimsPrincipleExtensions.cs
+++ b/src/EPR.Common/EPR.Common.Authorization/Extensions/ClaimsPrincipleExtensions.cs
@@ -37,7 +37,7 @@ public static class ClaimsPrincipleExtensions
     public static T GetData<T>(this ClaimsPrincipal claimsPrincipal, string name)
     {
         var claimsIdentity = claimsPrincipal.Identity as ClaimsIdentity;
-        var claim = claimsIdentity?.FindFirst(name);
+        var claim = claimsIdentity?.Claims.FirstOrDefault(c => c.Type == name);
 
         return claim != null ? JsonSerializer.Deserialize<T>(claim.Value) : default;
     }


### PR DESCRIPTION
It seems that if FindFirst is used on mocked claims they do not get returns, whereas FirstOrDefault they are.