### PR TITLE
Add devops ci build for main & PRs

### DIFF
--- a/build/pipelines/ci.yaml
+++ b/build/pipelines/ci.yaml
@@ -1,0 +1,65 @@
+trigger:
+  branches:
+    include:
+      - '*'
+  paths:
+    include:
+      - 'src/*'
+
+pool: DEFRA-COMMON-ubuntu2004-SSV3
+
+variables:
+  solutionFolder: src/EPR.Common
+  solution: src/EPR.Common/EPR.Common.sln
+  buildConfiguration: Release
+  sonarQubeProjectKey: epr-common
+  sonarQubeProjectName: epr-common
+
+stages:
+  - stage: Build_Test_Analyse
+    displayName: 'Build, Test & Analyse'
+    jobs:
+      - job: BuildTestAnalyse
+        displayName: 'Build, Test & Analyse'
+        steps:
+          - task: SonarQubePrepare@6
+            displayName: 'SonarQube Prepare'
+            inputs:
+              SonarQube: 'SonarQube'
+              scannerMode: 'MSBuild'
+              projectKey: $(sonarQubeProjectKey)
+              projectName: $(sonarQubeProjectName)
+              extraProperties: sonar.cs.opencover.reportsPaths="**/coverage.opencover.xml"
+
+          - task: DotNetCoreCLI@2
+            displayName: 'Restore'
+            inputs:
+              command: 'restore'
+              projects: $(solution)
+              feedsToUse: 'config'
+              nugetConfigPath: '$(solutionFolder)/NuGet.Config'
+
+          - task: DotNetCoreCLI@2
+            displayName: 'Build'
+            inputs:
+              command: 'build'
+              projects: $(solution)
+              arguments: '--configuration $(buildConfiguration) --no-restore'
+
+          - task: DotNetCoreCLI@2
+            displayName: 'Test'
+            inputs:
+              command: 'test'
+              projects: '$(solutionFolder)/**/*.Test*/*.csproj'
+              arguments: '--configuration $(buildConfiguration) --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=opencover'
+              publishTestResults: true
+
+          - task: SonarQubeAnalyze@6
+            displayName: 'SonarQube Analyze'
+            inputs:
+              jdkversion: 'JAVA_HOME_17_X64'
+
+          - task: SonarQubePublish@6
+            displayName: 'SonarQube Publish'
+            inputs:
+              pollingTimeoutSec: '300'


### PR DESCRIPTION
So we can see the sonarqube analysis before merging

Context: pulling common in as a subtree failed sonarqube, main of epr-common should by clean by the time it's in main - https://github.com/DEFRA/epr-regulator-service/pull/430

Pipeline code based on existing templates for common & webapps

https://dev.azure.com/defragovuk/RWD-CPR-EPR4P-ADO/_build?definitionId=10738