### PR TITLE
SUB-238: Logger registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ N/A
 N/A
 
 ## How To Debug
-N/A
+You can refererence these assemblies directly, or build a nuget package locally and reference that instead. Build the assembly in _Release_ configuration, and run the following command:
+```
+dotnet pack <project file> -o <output directory>
+```
+For further options, see the [documentation](https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet-pack).
 
 ## Additional Information
 See [User Authorization Middleware](https://eaflood.atlassian.net/wiki/spaces/MWR/pages/4346839200/User+Authorization+Middleware)

--- a/src/EPR.Common/EPR.Common.Functions.Test/AccessControl/HttpAuthenticatorTests.cs
+++ b/src/EPR.Common/EPR.Common.Functions.Test/AccessControl/HttpAuthenticatorTests.cs
@@ -11,15 +11,11 @@ using NSubstitute;
 public class HttpAuthenticatorTests
 {
     private HttpAuthenticator httpAuthenticator;
-    private ILogger<HttpAuthenticator> logger;
-    private ICancellationTokenAccessor cancellationTokenAccessor;
 
     [TestInitialize]
     public void Setup()
     {
-        this.logger = Substitute.For<ILogger<HttpAuthenticator>>();
-        this.cancellationTokenAccessor = Substitute.For<ICancellationTokenAccessor>();
-        this.httpAuthenticator = new HttpAuthenticator(this.logger, this.cancellationTokenAccessor);
+        this.httpAuthenticator = new HttpAuthenticator();
     }
 
     [TestMethod]

--- a/src/EPR.Common/EPR.Common.Functions/AccessControl/HttpAuthenticator.cs
+++ b/src/EPR.Common/EPR.Common.Functions/AccessControl/HttpAuthenticator.cs
@@ -7,18 +7,10 @@ using Microsoft.Extensions.Logging;
 
 public class HttpAuthenticator : IAuthenticator
     {
-        private readonly ICancellationTokenAccessor cancellationTokenAccessor;
-        private readonly ILogger<HttpAuthenticator> logger;
         private Guid? userId;
         private string? emailAddress;
         private Guid? customerOrganisationId;
         private Guid? customerId;
-
-        public HttpAuthenticator(ILogger<HttpAuthenticator> logger, ICancellationTokenAccessor cancellationTokenAccessor)
-        {
-            this.logger = logger;
-            this.cancellationTokenAccessor = cancellationTokenAccessor;
-        }
 
         public Guid UserId => this.userId ?? throw new NotSupportedException("UserId cannot be used before authentication");
 

--- a/src/EPR.Common/EPR.Common.Functions/Extensions/DependencyInjectionExtensions.cs
+++ b/src/EPR.Common/EPR.Common.Functions/Extensions/DependencyInjectionExtensions.cs
@@ -19,6 +19,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
 using Services;
@@ -32,13 +33,17 @@ public static class DependencyInjectionExtensions
             .AddTransient<IUnitOfWork, UnitOfWork>()
             .AddTransient<IEntityDecorator, CreatedUpdatedDecorator>();
 
-    public static IServiceCollection AddCommonServices(this IServiceCollection services) =>
-        services
-            .AddSingleton<ILoggerFactory, LoggerFactory>()
-            .AddSingleton(typeof(ILogger<>), typeof(Logger<>))
+    public static IServiceCollection AddCommonServices(this IServiceCollection services)
+    {
+        // only add logger if it has not already been added
+        services.TryAddSingleton(typeof(ILogger<>), typeof(Logger<>));
+        services.TryAddSingleton<ILoggerFactory, LoggerFactory>();
+
+        return services
             .AddTransient<ITimeService, TimeService>()
             .AddTransient<IHttpContextAccessor, HttpContextAccessor>()
             .AddScoped<ICancellationTokenAccessor, CancellationTokenAccessor>();
+    }
 
     public static IServiceCollection AddMockAuthentication(this IServiceCollection services, ConfigurationManager config)
     {


### PR DESCRIPTION
Only add ILogger to DI container if it has not already been added

This ensure that individual services can retain control of the logger, and use, for instance, serilog.

This show some serilog output when `AddCommonServices` has been called _after_ serilog registration, which would previously have been overwritten by the logger registration in `AddCommonServices`

<img width="758" height="124" alt="image" src="https://github.com/user-attachments/assets/2d273144-67b1-40c5-9604-84d756ce3188" />

<img width="561" height="367" alt="image" src="https://github.com/user-attachments/assets/475cbea6-09f4-48df-9d46-cd7d6f33e5da" />

<img width="550" height="183" alt="image" src="https://github.com/user-attachments/assets/880368db-71d4-4f1b-9c9f-b44487bc3c30" />
