### PR TITLE
ELSP-367 Move deployment template from ADO to GH

### DIFF
--- a/build/pipelines/build-test-push-package-authorization.yaml
+++ b/build/pipelines/build-test-push-package-authorization.yaml
@@ -32,8 +32,9 @@ variables:
 resources:
   repositories:
     - repository: CommonTemplates
-      name: RWD-CPR-EPR4P-ADO/epr-webapps-code-deploy-templates
-      type: git
+      name: defra/epr-webapps-code-deploy-templates
+      type: github
+      endpoint: defra
       ref: main
 
 stages:

--- a/build/pipelines/build-test-push-package-functions.yaml
+++ b/build/pipelines/build-test-push-package-functions.yaml
@@ -32,8 +32,9 @@ variables:
 resources:
   repositories:
     - repository: CommonTemplates
-      name: RWD-CPR-EPR4P-ADO/epr-webapps-code-deploy-templates
-      type: git
+      name: defra/epr-webapps-code-deploy-templates
+      type: github
+      endpoint: defra
       ref: main
 
 stages:

--- a/build/pipelines/build-test-push-package-logging.yaml
+++ b/build/pipelines/build-test-push-package-logging.yaml
@@ -32,8 +32,9 @@ variables:
 resources:
   repositories:
     - repository: CommonTemplates
-      name: RWD-CPR-EPR4P-ADO/epr-webapps-code-deploy-templates
-      type: git
+      name: defra/epr-webapps-code-deploy-templates
+      type: github
+      endpoint: defra
       ref: main
 
 stages:


### PR DESCRIPTION
Repoints the `epr-webapps-code-deploy-templates` repository resource from Azure DevOps to the GitHub org (`defra/epr-webapps-code-deploy-templates`) via the `defra` service connection. Part of the ADO->GitHub templates migration.